### PR TITLE
Small refactor and add @doc for assert_file

### DIFF
--- a/test/mix/tasks/phoenix.gen.jsroutes_test.exs
+++ b/test/mix/tasks/phoenix.gen.jsroutes_test.exs
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Phoenix.Gen.JsroutesTest do
 
   test "generate javascript routes for a specific phoenix router" do
     Mix.Tasks.Phoenix.Gen.Jsroutes.run(["Mix.RouterTest"])
-    assert_file "web/static/js/jsroutes.js", fn file ->
+    assert_contents "web/static/js/jsroutes.js", fn file ->
       assert file =~ "pageIndex() {"
       assert file =~ "return '/';"
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,25 +1,41 @@
 defmodule TestHelper do
   import ExUnit.Assertions
 
+  @doc """
+  Asserts file exists in the filesystem
+  """
   def assert_file(file) do
     assert File.regular?(file), "Expected #{file} to exist, but does not"
   end
 
-   def refute_file(file) do
-     refute File.regular?(file), "Expected #{file} to not exist, but it does"
-   end
+  @doc """
+  Asserts that file exists and its contents are matched by `match`.
+  `match` can be a binary, a regex or a list. If it's a list, every member of the list
+  must match with the file contents.
+  """
+  def assert_file(file, match) when is_list(match) do
+    assert_file file, &(Enum.each(match, fn(m) -> assert &1 =~ m end))
+  end
 
-   def assert_file(file, match) do
-     cond do
-       is_list(match) ->
-         assert_file file, &(Enum.each(match, fn(m) -> assert &1 =~ m end))
-       is_binary(match) or Regex.regex?(match) ->
-         assert_file file, &(assert &1 =~ match)
-       is_function(match, 1) ->
-         assert_file(file)
-         match.(File.read!(file))
-     end
-   end
+  def assert_file(file, match) when is_binary(match) or is_map(match) do
+    assert_file file, &(assert &1 =~ match)
+  end
+
+  @doc """
+  Assert that file exists and pass its contents to a function for further assertions.
+  """
+  def assert_contents(file, match) when is_function(match, 1) do
+    assert_file(file)
+    match.(File.read!(file))
+  end
+
+  @doc """
+  Assert that a file does NOT exist.
+  """
+  def refute_file(file) do
+    refute File.regular?(file), "Expected #{file} to not exist, but it does"
+  end
+
 end
 
 # Get Mix output sent to the current


### PR DESCRIPTION
The guard is_map is used to match against Regex, since every compiled Regex
internally is a map.
